### PR TITLE
DGPv2

### DIFF
--- a/contracts/Budget.sol
+++ b/contracts/Budget.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 
 import "./DGP.sol";
@@ -79,14 +79,14 @@ contract Budget {
         // limit number of active proposals
         require(
             _proposalCount < _maximumActiveProposals,
-            "Maximum active proposals reached"
+            "Budget: Maximum active proposals reached"
         );
         // must pay listing fee
-        require(msg.value == listingFee, "Buget listing fee is required");
+        require(msg.value == listingFee, "Budget: Budget listing fee is required");
         // must have duration and requested amount
-        require(requested > 0, "Requested amount cannot be less than 1");
-        require(duration > 0, "Requested duration cannot be less than 1");
-        require(duration < 13, "Requested duration cannot be greater than 12");
+        require(requested > 0, "Budget: Requested amount cannot be less than 1");
+        require(duration > 0, "Budget: Requested duration cannot be less than 1");
+        require(duration < 13, "Budget: Requested duration cannot be greater than 12");
         // create new proposal
         _currentProposalId++;
         _proposalCount++;
@@ -135,11 +135,11 @@ contract Budget {
         // must be a valid governor
         require(
             governanceInterface.isValidGovernor(msg.sender, true, true),
-            "Address is not a valid governor"
+            "Budget: Address is not a valid governor"
         );
         // must be a valid proposal
         int16 proposalRawIndex = getProposalIndex(proposalId);
-        require(proposalRawIndex >= 0, "Proposal not found");
+        require(proposalRawIndex >= 0, "Budget: Proposal not found");
         uint8 proposalIndex = uint8(uint16(proposalRawIndex));
         // create unique vote value to handle reusing memory of old budgets
         uint16 voteData = uint16(proposalId) << 8;
@@ -162,7 +162,7 @@ contract Budget {
         // log vote
         votes[proposalIndex][msg.sender] = voteData;
         // update governor ping
-        governanceInterface.ping();
+        governanceInterface.ping(msg.sender);
     }
 
     /** @dev Function to get a a governors current vote for the proposals.
@@ -288,7 +288,7 @@ contract Budget {
      */
     function proposalVoteStatus(uint8 proposalId) public view returns (Vote) {
         int16 proposalRawIndex = getProposalIndex(proposalId);
-        require(proposalRawIndex >= 0, "Proposal not found");
+        require(proposalRawIndex >= 0, "Budget: Proposal not found");
         uint8 proposalIndex = uint8(uint16(proposalRawIndex));
         return getVote(votes[proposalIndex][msg.sender], proposalId);
     }

--- a/contracts/DGP.sol
+++ b/contracts/DGP.sol
@@ -86,7 +86,7 @@ contract DGP {
     uint64 public immutable  defaultMinRelayTxFee = 1E9;
     uint64 public immutable  defaultIncrementalRelayFee = 1E9;
     uint64 public immutable defaultDustRelayFee = 3E9;
-    uint32 public immutable defaultMinGasPrice = 5000;
+    uint32 public immutable defaultMinGasPrice = 1;
     uint64 public immutable defaultBlockGasLimit = 4E7;
     uint32 public immutable defaultBlockSize = 2E6;
     uint32[39] public defaultGasSchedule = [

--- a/contracts/DGP.sol
+++ b/contracts/DGP.sol
@@ -273,7 +273,7 @@ contract DGP {
         } else if (proposalType == ProposalType.BLOCKSIZE) {
             BlockSizeInterface ci = BlockSizeInterface(proposalAddress);
             uint32[1] memory size = ci.getBlockSize();
-            if (size[0] > minBlockSize && size[0] <= maxBlockSize) return true;
+            if (size[0] >= minBlockSize && size[0] <= maxBlockSize) return true;
         } else if (proposalType == ProposalType.MINGASPRICE) {
             MinGasPriceInterface ci = MinGasPriceInterface(proposalAddress);
             uint32[1] memory price = ci.getMinGasPrice();
@@ -281,7 +281,7 @@ contract DGP {
         } else if (proposalType == ProposalType.BLOCKGASLIMIT) {
             BlockGasLimitInterface ci = BlockGasLimitInterface(proposalAddress);
             uint64[1] memory limit = ci.getBlockGasLimit();
-            if (limit[0] > minBlockGasLimit && limit[0] <= maxBlockGasLimit) return true;
+            if (limit[0] >= minBlockGasLimit && limit[0] <= maxBlockGasLimit) return true;
         } else if (proposalType == ProposalType.TRANSACTIONFEERATES) {
             TransactionFeeRatesInterface ci = TransactionFeeRatesInterface(
                 proposalAddress

--- a/contracts/DGP.sol
+++ b/contracts/DGP.sol
@@ -86,7 +86,7 @@ contract DGP {
     uint64 public immutable  defaultMinRelayTxFee = 1E9;
     uint64 public immutable  defaultIncrementalRelayFee = 1E9;
     uint64 public immutable defaultDustRelayFee = 3E9;
-    uint32 public immutable defaultMinGasPrice = 1;
+    uint32 public immutable defaultMinGasPrice = 5000;
     uint64 public immutable defaultBlockGasLimit = 4E7;
     uint32 public immutable defaultBlockSize = 2E6;
     uint32[39] public defaultGasSchedule = [

--- a/contracts/DGP.sol
+++ b/contracts/DGP.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.7;
+pragma solidity 0.8.7;
 
 import "./Governance.sol";
 
@@ -154,7 +154,7 @@ contract DGP {
     // ------- PROPOSAL VOTING ------
     // ------------------------------
 
-    // add new proposal or vote on existing proposal to change the governor collateral
+    // add new proposal or vote on existing proposal  
     function addProposal(ProposalType proposalType, address proposalAddress)
         public
     {
@@ -166,20 +166,20 @@ contract DGP {
         // must be minimum governors
         require(
             governorCount >= _minimumGovernors,
-            "Not enough governors to enable voting"
+            "DGP: Not enough governors to enable voting"
         );
         // address must be governor
         require(
             contractInterface.isValidGovernor(msg.sender, true, true),
-            "Only valid governors can create proposals"
+            "DGP: Only valid governors can create proposals"
         );
         // update ping time
-        contractInterface.ping();
+        contractInterface.ping(msg.sender);
         // check a vote isn't active
         if (!proposal.onVote) {
             require(
                 validateProposedContract(proposalType, proposalAddress) == true,
-                "The proposed contract did not operate as expected"
+                "DGP: The proposed contract did not operate as expected"
             );
             proposal.onVote = true; // put proposal on vote, no changes until vote is setteled or removed
             proposal.proposalAddress = proposalAddress; // set new proposal for vote

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "metrix-dgp",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "main": "test/index.js",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
Final updates to the DGPv2 contracts.

- Additional `ping(address)` command which can only be called by the DGP and Budget contracts, to allow DGP proposals or voting for Budget proposals to also count as a ping for the governor
- Hardcoded min, max and default values for blockGasLimit, blockSize, budgetFee, gasSchedule, governanceCollateral, minGasPrice and transactionFeeRates. This will prevent the governors from passing proposals that could stop the chain.
- Check that provider contracts return valid data after they are already in effect preventing a malicious contract from becoming a provider by using the new defaults in cases they are out of bounds.
- Add more verbose revert messages.
- Pin solidity compiler (0.8.7) 
- Bump package.json version




